### PR TITLE
Replace Gatsby service worker with cleanup script

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,8 @@
 
 [build.environment]
   NODE_VERSION = "22"
+
+[[headers]]
+  for = "/sw.js"
+  [headers.values]
+    Cache-Control = "no-cache, no-store, must-revalidate"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,19 @@
+// This service worker replaces the old Gatsby service worker.
+// It clears all caches and unregisters itself.
+// Can be safely removed once all returning visitors have loaded the new site.
+
+self.addEventListener("install", () => {
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((cacheNames) =>
+        Promise.all(cacheNames.map((cacheName) => caches.delete(cacheName)))
+      )
+      .then(() => self.clients.claim())
+      .then(() => self.registration.unregister())
+  );
+});

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -38,6 +38,15 @@ const headerLink = currentPath === "/blog/" || currentPath === "/blog" ? "/blog/
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={metaDescription} />
     {keywords.length > 0 && <meta name="keywords" content={keywords.join(", ")} />}
+    <script is:inline>
+      if ("serviceWorker" in navigator) {
+        navigator.serviceWorker.getRegistrations().then(function (registrations) {
+          for (var i = 0; i < registrations.length; i++) {
+            registrations[i].unregister();
+          }
+        });
+      }
+    </script>
   </head>
   <body>
     <div class="min-h-screen">


### PR DESCRIPTION
## Summary
This PR replaces the old Gatsby service worker with a new cleanup service worker that clears all caches and unregisters itself, enabling a smooth migration away from Gatsby's caching strategy.

## Key Changes
- **Added new service worker** (`public/sw.js`): A minimal service worker that clears all existing caches on activation and unregisters itself, ensuring old Gatsby caches don't interfere with the new site
- **Added service worker unregistration script** in `Layout.astro`: An inline script that immediately unregisters any existing service worker registrations when the page loads, providing an additional cleanup mechanism for returning visitors
- **Updated Netlify cache headers**: Added cache-control headers for `sw.js` to prevent caching (`no-cache, no-store, must-revalidate`), ensuring visitors always get the latest cleanup service worker

## Implementation Details
The cleanup is handled in two ways:
1. **Immediate unregistration**: The inline script in the layout unregisters any active service workers on page load
2. **Cache cleanup**: The new service worker clears all caches during its activation phase

The service worker file includes a comment noting it can be safely removed once all returning visitors have loaded the new site, indicating this is a temporary migration aid.

https://claude.ai/code/session_01QrpTHreWueUow9p6xGuzQ5