### PR TITLE
chore: add Astro check as required quality gate

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -47,6 +47,19 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm run lint
 
+  check:
+    name: check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run check
+
   build:
     name: build
     runs-on: ubuntu-latest
@@ -71,6 +84,7 @@ jobs:
     needs:
       - format
       - lint
+      - check
       - build
     env:
       DEPLOY_AUTH_TOKEN: ${{ secrets.DEPLOY_AUTH_TOKEN }}
@@ -181,6 +195,7 @@ jobs:
     needs:
       - format
       - lint
+      - check
       - build
     env:
       DEPLOY_AUTH_TOKEN: ${{ secrets.DEPLOY_AUTH_TOKEN }}

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -115,11 +115,7 @@ jobs:
       - name: Publish preview URL
         run: |
           deploy_url="${{ steps.deploy.outputs.deploy_url }}"
-          {
-            echo "### Preview Deploy"
-            echo
-            echo "Preview URL: ${deploy_url}"
-          } >> "$GITHUB_STEP_SUMMARY"
+          echo "Preview URL: ${deploy_url}" >> "$GITHUB_STEP_SUMMARY"
       - name: Upsert preview comment
         uses: actions/github-script@v7
         env:
@@ -131,12 +127,7 @@ jobs:
             const owner = context.repo.owner
             const repo = context.repo.repo
 
-            const body = [
-              marker,
-              '### Preview Deploy',
-              '',
-              `- Preview URL: [${process.env.DEPLOY_URL}](${process.env.DEPLOY_URL})`,
-            ].join('\n')
+            const body = `${marker}\nPreview URL: ${process.env.DEPLOY_URL}`
 
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner,

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -110,43 +110,20 @@ jobs:
       - name: Trigger preview deploy
         id: deploy
         run: |
-          deploy_alias="pr-${{ github.event.pull_request.number }}"
-          pnpm --silent run deploy:preview -- --alias "${deploy_alias}" > deploy-result.json
+          pnpm --silent run deploy:preview > deploy-result.json
           node scripts/extract-deploy-url.mjs deploy-result.json >> "$GITHUB_OUTPUT"
-
-          deploy_url="$(node -e 'const fs=require("node:fs");const p=JSON.parse(fs.readFileSync("deploy-result.json","utf8"));process.stdout.write(p.deploy_url||p.url||"")')"
-          deploy_host="${deploy_url#https://}"
-          deploy_host="${deploy_host#http://}"
-          deploy_host="${deploy_host%%/*}"
-          base_host="${deploy_host#*--}"
-          alias_url="https://${deploy_alias}--${base_host}"
-
-          preview_url="${deploy_url}"
-          if curl -fsSI --max-time 10 "${alias_url}" >/dev/null 2>&1; then
-            preview_url="${alias_url}"
-          fi
-
-          echo "deploy_alias=${deploy_alias}" >> "$GITHUB_OUTPUT"
-          echo "preview_url=${preview_url}" >> "$GITHUB_OUTPUT"
       - name: Publish preview URL
         run: |
           deploy_url="${{ steps.deploy.outputs.deploy_url }}"
-          preview_url="${{ steps.deploy.outputs.preview_url }}"
-          deploy_alias="${{ steps.deploy.outputs.deploy_alias }}"
           {
             echo "### Preview Deploy"
             echo
-            echo "Preview URL: ${preview_url}"
-            echo
-            echo "Deploy Permalink: ${deploy_url}"
-            echo
-            echo "Alias: ${deploy_alias}"
+            echo "Preview URL: ${deploy_url}"
           } >> "$GITHUB_STEP_SUMMARY"
       - name: Upsert preview comment
         uses: actions/github-script@v7
         env:
           DEPLOY_URL: ${{ steps.deploy.outputs.deploy_url }}
-          PREVIEW_URL: ${{ steps.deploy.outputs.preview_url }}
         with:
           script: |
             const marker = '<!-- preview-deploy-comment -->'
@@ -158,8 +135,7 @@ jobs:
               marker,
               '### Preview Deploy',
               '',
-              `- Preview URL: [${process.env.PREVIEW_URL}](${process.env.PREVIEW_URL})`,
-              `- Deploy Permalink: [${process.env.DEPLOY_URL}](${process.env.DEPLOY_URL})`,
+              `- Preview URL: [${process.env.DEPLOY_URL}](${process.env.DEPLOY_URL})`,
             ].join('\n')
 
             const comments = await github.paginate(github.rest.issues.listComments, {

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -113,28 +113,40 @@ jobs:
           deploy_alias="pr-${{ github.event.pull_request.number }}"
           pnpm --silent run deploy:preview -- --alias "${deploy_alias}" > deploy-result.json
           node scripts/extract-deploy-url.mjs deploy-result.json >> "$GITHUB_OUTPUT"
-      - name: Publish preview URL
-        run: |
-          deploy_url="${{ steps.deploy.outputs.deploy_url }}"
+
+          deploy_url="$(node -e 'const fs=require("node:fs");const p=JSON.parse(fs.readFileSync("deploy-result.json","utf8"));process.stdout.write(p.deploy_url||p.url||"")')"
           deploy_host="${deploy_url#https://}"
           deploy_host="${deploy_host#http://}"
           deploy_host="${deploy_host%%/*}"
           base_host="${deploy_host#*--}"
-          alias_url="https://pr-${{ github.event.pull_request.number }}--${base_host}"
+          alias_url="https://${deploy_alias}--${base_host}"
+
+          preview_url="${deploy_url}"
+          if curl -fsSI --max-time 10 "${alias_url}" >/dev/null 2>&1; then
+            preview_url="${alias_url}"
+          fi
+
+          echo "deploy_alias=${deploy_alias}" >> "$GITHUB_OUTPUT"
+          echo "preview_url=${preview_url}" >> "$GITHUB_OUTPUT"
+      - name: Publish preview URL
+        run: |
+          deploy_url="${{ steps.deploy.outputs.deploy_url }}"
+          preview_url="${{ steps.deploy.outputs.preview_url }}"
+          deploy_alias="${{ steps.deploy.outputs.deploy_alias }}"
           {
             echo "### Preview Deploy"
             echo
-            echo "Preview URL: ${alias_url}"
+            echo "Preview URL: ${preview_url}"
             echo
             echo "Deploy Permalink: ${deploy_url}"
             echo
-            echo "Alias: pr-${{ github.event.pull_request.number }}"
+            echo "Alias: ${deploy_alias}"
           } >> "$GITHUB_STEP_SUMMARY"
       - name: Upsert preview comment
         uses: actions/github-script@v7
         env:
           DEPLOY_URL: ${{ steps.deploy.outputs.deploy_url }}
-          DEPLOY_ALIAS: pr-${{ github.event.pull_request.number }}
+          PREVIEW_URL: ${{ steps.deploy.outputs.preview_url }}
         with:
           script: |
             const marker = '<!-- preview-deploy-comment -->'
@@ -142,22 +154,11 @@ jobs:
             const owner = context.repo.owner
             const repo = context.repo.repo
 
-            let aliasUrl = process.env.DEPLOY_URL
-            try {
-              const deployHost = new URL(process.env.DEPLOY_URL).host
-              const [, baseHost] = deployHost.split(/--(.+)/)
-              if (baseHost) {
-                aliasUrl = `https://${process.env.DEPLOY_ALIAS}--${baseHost}`
-              }
-            } catch {
-              aliasUrl = process.env.DEPLOY_URL
-            }
-
             const body = [
               marker,
               '### Preview Deploy',
               '',
-              `- Preview URL: [${aliasUrl}](${aliasUrl})`,
+              `- Preview URL: [${process.env.PREVIEW_URL}](${process.env.PREVIEW_URL})`,
               `- Deploy Permalink: [${process.env.DEPLOY_URL}](${process.env.DEPLOY_URL})`,
             ].join('\n')
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm exec lint-staged
+pnpm exec lint-staged && pnpm run check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,7 @@ Follow these instructions unless a direct user request overrides them.
   1. Run `pnpm run astro -- check` when relevant.
   2. Run `pnpm run build` for build-affecting changes.
   3. Use `pnpm run preview` for UI sanity checks when pages/styles changed.
+- `astro dev`, `astro check`, and `astro build` already run `astro sync`, so do not add a separate CI `sync` step unless you need type generation without those commands.
 - If commands are not run, state why.
 - Do not introduce broad formatting churn.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ Follow these instructions unless a direct user request overrides them.
 ## Build/Lint/Test Commands
 
 - Build: `pnpm run build`
+- Check: `pnpm run check`
 - Dev: `pnpm run dev`
 - Preview: `pnpm run preview`
 - Astro CLI passthrough: `pnpm run astro -- <subcommand>`
@@ -75,7 +76,7 @@ Follow these instructions unless a direct user request overrides them.
 
 - Pre-commit hook runs staged-file checks/fixes via `lint-staged` (`format` and `lint:fix` behavior on staged files).
 - Primary workflow: `.github/workflows/quality-checks.yml`.
-- Required checks for `master`: `format`, `lint`, `build`.
+- Required checks for `master`: `format`, `lint`, `check`, `build`.
 
 ## Formatting Commands
 
@@ -125,7 +126,7 @@ Follow these instructions unless a direct user request overrides them.
 
 ### Types
 
-- TypeScript config extends `astro/tsconfigs/strict`.
+- TypeScript config extends `astro/tsconfigs/strictest`.
 - Prefer explicit props interfaces in Astro components/layouts.
 - Use schema validation in `src/content.config.ts` for content safety.
 - Avoid `any`; use inferred, narrowed, or declared concrete types.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "scripts": {
     "astro": "astro",
     "build": "astro build",
+    "check": "astro check",
     "dev": "astro dev",
     "deploy:preview": "pnpm exec netlify deploy --auth \"$DEPLOY_AUTH_TOKEN\" --site \"$DEPLOY_SITE_ID\" --dir dist --no-build --json",
     "deploy:production": "pnpm exec netlify deploy --auth \"$DEPLOY_AUTH_TOKEN\" --site \"$DEPLOY_SITE_ID\" --dir dist --no-build --prod --json",
@@ -38,6 +39,7 @@
     "tailwindcss": "^4.0.0"
   },
   "devDependencies": {
+    "@astrojs/check": "^0.9.6",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
     "netlify-cli": "^23.15.1",
@@ -45,7 +47,8 @@
     "prettier": "^3.8.1",
     "prettier-plugin-astro": "^0.14.1",
     "prettier-plugin-tailwindcss": "^0.7.2",
-    "sharp": "^0.34.5"
+    "sharp": "^0.34.5",
+    "typescript": "^5.9.3"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,mjs,cjs}": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
         specifier: ^4.0.0
         version: 4.2.0
     devDependencies:
+      "@astrojs/check":
+        specifier: ^0.9.6
+        version: 0.9.6(prettier-plugin-astro@0.14.1)(prettier@3.8.1)(typescript@5.9.3)
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -44,8 +47,20 @@ importers:
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
 
 packages:
+  "@astrojs/check@0.9.6":
+    resolution:
+      {
+        integrity: sha512-jlaEu5SxvSgmfGIFfNgcn5/f+29H61NJzEMfAZ82Xopr4XBchXB1GVlcJsE+elUlsYSbXlptZLX+JMG3b/wZEA==,
+      }
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0
+
   "@astrojs/compiler@2.13.1":
     resolution:
       {
@@ -57,6 +72,21 @@ packages:
       {
         integrity: sha512-vreGnYSSKhAjFJCWAwe/CNhONvoc5lokxtRoZims+0wa3KbHBdPHSSthJsKxPd8d/aic6lWKpRTYGY/hsgK6EA==,
       }
+
+  "@astrojs/language-server@2.16.3":
+    resolution:
+      {
+        integrity: sha512-yO5K7RYCMXUfeDlnU6UnmtnoXzpuQc0yhlaCNZ67k1C/MiwwwvMZz+LGa+H35c49w5QBfvtr4w4Zcf5PcH8uYA==,
+      }
+    hasBin: true
+    peerDependencies:
+      prettier: ^3.0.0
+      prettier-plugin-astro: ">=0.11.0"
+    peerDependenciesMeta:
+      prettier:
+        optional: true
+      prettier-plugin-astro:
+        optional: true
 
   "@astrojs/markdown-remark@6.3.10":
     resolution:
@@ -86,6 +116,12 @@ packages:
         integrity: sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==,
       }
     engines: { node: 18.20.8 || ^20.3.0 || >=22.0.0 }
+
+  "@astrojs/yaml2ts@0.2.2":
+    resolution:
+      {
+        integrity: sha512-GOfvSr5Nqy2z5XiwqTouBBpy5FyI6DEe+/g/Mk5am9SjILN1S5fOEvYK0GuWHg98yS/dobP4m8qyqw/URW35fQ==,
+      }
 
   "@babel/code-frame@7.29.0":
     resolution:
@@ -192,6 +228,48 @@ packages:
         integrity: sha512-Y6+WUMsTFWE5jb20IFP4YGa5IrGY/+a/FbOSjDF/wz9gepU2hwCYSXRHP/vPwBvwcY3SVMASt4yXxbXNXigmZQ==,
       }
     engines: { node: ">=18" }
+
+  "@emmetio/abbreviation@2.3.3":
+    resolution:
+      {
+        integrity: sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==,
+      }
+
+  "@emmetio/css-abbreviation@2.1.8":
+    resolution:
+      {
+        integrity: sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw==,
+      }
+
+  "@emmetio/css-parser@0.4.1":
+    resolution:
+      {
+        integrity: sha512-2bC6m0MV/voF4CTZiAbG5MWKbq5EBmDPKu9Sb7s7nVcEzNQlrZP6mFFFlIaISM8X6514H9shWMme1fCm8cWAfQ==,
+      }
+
+  "@emmetio/html-matcher@1.3.0":
+    resolution:
+      {
+        integrity: sha512-NTbsvppE5eVyBMuyGfVu2CRrLvo7J4YHb6t9sBFLyY03WYhXET37qA4zOYUjBWFCRHO7pS1B9khERtY0f5JXPQ==,
+      }
+
+  "@emmetio/scanner@1.0.4":
+    resolution:
+      {
+        integrity: sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA==,
+      }
+
+  "@emmetio/stream-reader-utils@0.1.0":
+    resolution:
+      {
+        integrity: sha512-ZsZ2I9Vzso3Ho/pjZFsmmZ++FWeEd/txqybHTm4OgaZzdS8V9V/YYWQwg5TC38Z7uLWUV1vavpLLbjJtKubR1A==,
+      }
+
+  "@emmetio/stream-reader@2.2.0":
+    resolution:
+      {
+        integrity: sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw==,
+      }
 
   "@emnapi/runtime@1.8.1":
     resolution:
@@ -2870,6 +2948,56 @@ packages:
     engines: { node: ">=18" }
     hasBin: true
 
+  "@volar/kit@2.4.28":
+    resolution:
+      {
+        integrity: sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==,
+      }
+    peerDependencies:
+      typescript: "*"
+
+  "@volar/language-core@2.4.28":
+    resolution:
+      {
+        integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==,
+      }
+
+  "@volar/language-server@2.4.28":
+    resolution:
+      {
+        integrity: sha512-NqcLnE5gERKuS4PUFwlhMxf6vqYo7hXtbMFbViXcbVkbZ905AIVWhnSo0ZNBC2V127H1/2zP7RvVOVnyITFfBw==,
+      }
+
+  "@volar/language-service@2.4.28":
+    resolution:
+      {
+        integrity: sha512-Rh/wYCZJrI5vCwMk9xyw/Z+MsWxlJY1rmMZPsxUoJKfzIRjS/NF1NmnuEcrMbEVGja00aVpCsInJfixQTMdvLw==,
+      }
+
+  "@volar/source-map@2.4.28":
+    resolution:
+      {
+        integrity: sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==,
+      }
+
+  "@volar/typescript@2.4.28":
+    resolution:
+      {
+        integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==,
+      }
+
+  "@vscode/emmet-helper@2.11.0":
+    resolution:
+      {
+        integrity: sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw==,
+      }
+
+  "@vscode/l10n@0.0.18":
+    resolution:
+      {
+        integrity: sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==,
+      }
+
   "@vue/compiler-core@3.5.28":
     resolution:
       {
@@ -3048,6 +3176,17 @@ packages:
         integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==,
       }
     engines: { node: ">= 14" }
+
+  ajv-draft-04@1.0.0:
+    resolution:
+      {
+        integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==,
+      }
+    peerDependencies:
+      ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
 
   ajv-errors@3.0.0:
     resolution:
@@ -4393,6 +4532,12 @@ packages:
     resolution:
       {
         integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==,
+      }
+
+  emmet@2.4.11:
+    resolution:
+      {
+        integrity: sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==,
       }
 
   emoji-regex@10.6.0:
@@ -6261,6 +6406,18 @@ packages:
         integrity: sha512-QObKu6nxy7NsxqR0VK4rkXnsNr5L9ElJaGEg+ucJ6J7/suoKZ0n+p76cu9aCqowytxEbwYNzvrMerfMkXneF5A==,
       }
 
+  jsonc-parser@2.3.1:
+    resolution:
+      {
+        integrity: sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==,
+      }
+
+  jsonc-parser@3.3.1:
+    resolution:
+      {
+        integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==,
+      }
+
   jsonpointer@5.0.1:
     resolution:
       {
@@ -6325,6 +6482,13 @@ packages:
     resolution:
       {
         integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==,
+      }
+    engines: { node: ">=6" }
+
+  kleur@4.1.5:
+    resolution:
+      {
+        integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==,
       }
     engines: { node: ">=6" }
 
@@ -6574,6 +6738,12 @@ packages:
     resolution:
       {
         integrity: sha512-LO37ZnhmBVx0GvOU/caQuipEh4GN82TcWv3yHlebGDgOxbxiwwzW5Pcx2AcvpIv2WmvmSMoC492yQFNhy/l/UQ==,
+      }
+
+  lodash@4.17.21:
+    resolution:
+      {
+        integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==,
       }
 
   lodash@4.17.23:
@@ -7229,6 +7399,12 @@ packages:
         integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
       }
 
+  muggle-string@0.4.1:
+    resolution:
+      {
+        integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==,
+      }
+
   multiparty@4.2.3:
     resolution:
       {
@@ -7810,6 +7986,12 @@ packages:
         integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==,
       }
     engines: { node: ">= 0.8" }
+
+  path-browserify@1.0.1:
+    resolution:
+      {
+        integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==,
+      }
 
   path-exists@5.0.0:
     resolution:
@@ -8462,6 +8644,18 @@ packages:
     resolution:
       {
         integrity: sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==,
+      }
+
+  request-light@0.5.8:
+    resolution:
+      {
+        integrity: sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==,
+      }
+
+  request-light@0.7.0:
+    resolution:
+      {
+        integrity: sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q==,
       }
 
   require-directory@2.1.1:
@@ -9561,6 +9755,18 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  typesafe-path@0.2.2:
+    resolution:
+      {
+        integrity: sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==,
+      }
+
+  typescript-auto-import-cache@0.3.6:
+    resolution:
+      {
+        integrity: sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ==,
+      }
+
   typescript@5.9.3:
     resolution:
       {
@@ -9962,6 +10168,149 @@ packages:
       vite:
         optional: true
 
+  volar-service-css@0.0.68:
+    resolution:
+      {
+        integrity: sha512-lJSMh6f3QzZ1tdLOZOzovLX0xzAadPhx8EKwraDLPxBndLCYfoTvnNuiFFV8FARrpAlW5C0WkH+TstPaCxr00Q==,
+      }
+    peerDependencies:
+      "@volar/language-service": ~2.4.0
+    peerDependenciesMeta:
+      "@volar/language-service":
+        optional: true
+
+  volar-service-emmet@0.0.68:
+    resolution:
+      {
+        integrity: sha512-nHvixrRQ83EzkQ4G/jFxu9Y4eSsXS/X2cltEPDM+K9qZmIv+Ey1w0tg1+6caSe8TU5Hgw4oSTwNMf/6cQb3LzQ==,
+      }
+    peerDependencies:
+      "@volar/language-service": ~2.4.0
+    peerDependenciesMeta:
+      "@volar/language-service":
+        optional: true
+
+  volar-service-html@0.0.68:
+    resolution:
+      {
+        integrity: sha512-fru9gsLJxy33xAltXOh4TEdi312HP80hpuKhpYQD4O5hDnkNPEBdcQkpB+gcX0oK0VxRv1UOzcGQEUzWCVHLfA==,
+      }
+    peerDependencies:
+      "@volar/language-service": ~2.4.0
+    peerDependenciesMeta:
+      "@volar/language-service":
+        optional: true
+
+  volar-service-prettier@0.0.68:
+    resolution:
+      {
+        integrity: sha512-grUmWHkHlebMOd6V8vXs2eNQUw/bJGJMjekh/EPf/p2ZNTK0Uyz7hoBRngcvGfJHMsSXZH8w/dZTForIW/4ihw==,
+      }
+    peerDependencies:
+      "@volar/language-service": ~2.4.0
+      prettier: ^2.2 || ^3.0
+    peerDependenciesMeta:
+      "@volar/language-service":
+        optional: true
+      prettier:
+        optional: true
+
+  volar-service-typescript-twoslash-queries@0.0.68:
+    resolution:
+      {
+        integrity: sha512-NugzXcM0iwuZFLCJg47vI93su5YhTIweQuLmZxvz5ZPTaman16JCvmDZexx2rd5T/75SNuvvZmrTOTNYUsfe5w==,
+      }
+    peerDependencies:
+      "@volar/language-service": ~2.4.0
+    peerDependenciesMeta:
+      "@volar/language-service":
+        optional: true
+
+  volar-service-typescript@0.0.68:
+    resolution:
+      {
+        integrity: sha512-z7B/7CnJ0+TWWFp/gh2r5/QwMObHNDiQiv4C9pTBNI2Wxuwymd4bjEORzrJ/hJ5Yd5+OzeYK+nFCKevoGEEeKw==,
+      }
+    peerDependencies:
+      "@volar/language-service": ~2.4.0
+    peerDependenciesMeta:
+      "@volar/language-service":
+        optional: true
+
+  volar-service-yaml@0.0.68:
+    resolution:
+      {
+        integrity: sha512-84XgE02LV0OvTcwfqhcSwVg4of3MLNUWPMArO6Aj8YXqyEVnPu8xTEMY2btKSq37mVAPuaEVASI4e3ptObmqcA==,
+      }
+    peerDependencies:
+      "@volar/language-service": ~2.4.0
+    peerDependenciesMeta:
+      "@volar/language-service":
+        optional: true
+
+  vscode-css-languageservice@6.3.9:
+    resolution:
+      {
+        integrity: sha512-1tLWfp+TDM5ZuVWht3jmaY5y7O6aZmpeXLoHl5bv1QtRsRKt4xYGRMmdJa5Pqx/FTkgRbsna9R+Gn2xE+evVuA==,
+      }
+
+  vscode-html-languageservice@5.6.1:
+    resolution:
+      {
+        integrity: sha512-5Mrqy5CLfFZUgkyhNZLA1Ye5g12Cb/v6VM7SxUzZUaRKWMDz4md+y26PrfRTSU0/eQAl3XpO9m2og+GGtDMuaA==,
+      }
+
+  vscode-json-languageservice@4.1.8:
+    resolution:
+      {
+        integrity: sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg==,
+      }
+    engines: { npm: ">=7.0.0" }
+
+  vscode-jsonrpc@8.2.0:
+    resolution:
+      {
+        integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==,
+      }
+    engines: { node: ">=14.0.0" }
+
+  vscode-languageserver-protocol@3.17.5:
+    resolution:
+      {
+        integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==,
+      }
+
+  vscode-languageserver-textdocument@1.0.12:
+    resolution:
+      {
+        integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==,
+      }
+
+  vscode-languageserver-types@3.17.5:
+    resolution:
+      {
+        integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==,
+      }
+
+  vscode-languageserver@9.0.1:
+    resolution:
+      {
+        integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==,
+      }
+    hasBin: true
+
+  vscode-nls@5.2.0:
+    resolution:
+      {
+        integrity: sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==,
+      }
+
+  vscode-uri@3.1.0:
+    resolution:
+      {
+        integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==,
+      }
+
   wcwidth@1.0.1:
     resolution:
       {
@@ -10175,6 +10524,21 @@ packages:
       }
     engines: { node: ">=18" }
 
+  yaml-language-server@1.19.2:
+    resolution:
+      {
+        integrity: sha512-9F3myNmJzUN/679jycdMxqtydPSDRAarSj3wPiF7pchEPnO9Dg07Oc+gIYLqXR4L+g+FSEVXXv2+mr54StLFOg==,
+      }
+    hasBin: true
+
+  yaml@2.7.1:
+    resolution:
+      {
+        integrity: sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==,
+      }
+    engines: { node: ">= 14" }
+    hasBin: true
+
   yaml@2.8.2:
     resolution:
       {
@@ -10274,9 +10638,46 @@ packages:
       }
 
 snapshots:
+  "@astrojs/check@0.9.6(prettier-plugin-astro@0.14.1)(prettier@3.8.1)(typescript@5.9.3)":
+    dependencies:
+      "@astrojs/language-server": 2.16.3(prettier-plugin-astro@0.14.1)(prettier@3.8.1)(typescript@5.9.3)
+      chokidar: 4.0.3
+      kleur: 4.1.5
+      typescript: 5.9.3
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - prettier
+      - prettier-plugin-astro
+
   "@astrojs/compiler@2.13.1": {}
 
   "@astrojs/internal-helpers@0.7.5": {}
+
+  "@astrojs/language-server@2.16.3(prettier-plugin-astro@0.14.1)(prettier@3.8.1)(typescript@5.9.3)":
+    dependencies:
+      "@astrojs/compiler": 2.13.1
+      "@astrojs/yaml2ts": 0.2.2
+      "@jridgewell/sourcemap-codec": 1.5.5
+      "@volar/kit": 2.4.28(typescript@5.9.3)
+      "@volar/language-core": 2.4.28
+      "@volar/language-server": 2.4.28
+      "@volar/language-service": 2.4.28
+      muggle-string: 0.4.1
+      tinyglobby: 0.2.15
+      volar-service-css: 0.0.68(@volar/language-service@2.4.28)
+      volar-service-emmet: 0.0.68(@volar/language-service@2.4.28)
+      volar-service-html: 0.0.68(@volar/language-service@2.4.28)
+      volar-service-prettier: 0.0.68(@volar/language-service@2.4.28)(prettier@3.8.1)
+      volar-service-typescript: 0.0.68(@volar/language-service@2.4.28)
+      volar-service-typescript-twoslash-queries: 0.0.68(@volar/language-service@2.4.28)
+      volar-service-yaml: 0.0.68(@volar/language-service@2.4.28)
+      vscode-html-languageservice: 5.6.1
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      prettier: 3.8.1
+      prettier-plugin-astro: 0.14.1
+    transitivePeerDependencies:
+      - typescript
 
   "@astrojs/markdown-remark@6.3.10":
     dependencies:
@@ -10338,6 +10739,10 @@ snapshots:
       which-pm-runs: 1.1.0
     transitivePeerDependencies:
       - supports-color
+
+  "@astrojs/yaml2ts@0.2.2":
+    dependencies:
+      yaml: 2.8.2
 
   "@babel/code-frame@7.29.0":
     dependencies:
@@ -10408,6 +10813,29 @@ snapshots:
     dependencies:
       gonzales-pe: 4.3.0
       node-source-walk: 7.0.1
+
+  "@emmetio/abbreviation@2.3.3":
+    dependencies:
+      "@emmetio/scanner": 1.0.4
+
+  "@emmetio/css-abbreviation@2.1.8":
+    dependencies:
+      "@emmetio/scanner": 1.0.4
+
+  "@emmetio/css-parser@0.4.1":
+    dependencies:
+      "@emmetio/stream-reader": 2.2.0
+      "@emmetio/stream-reader-utils": 0.1.0
+
+  "@emmetio/html-matcher@1.3.0":
+    dependencies:
+      "@emmetio/scanner": 1.0.4
+
+  "@emmetio/scanner@1.0.4": {}
+
+  "@emmetio/stream-reader-utils@0.1.0": {}
+
+  "@emmetio/stream-reader@2.2.0": {}
 
   "@emnapi/runtime@1.8.1":
     dependencies:
@@ -11950,6 +12378,56 @@ snapshots:
       - rollup
       - supports-color
 
+  "@volar/kit@2.4.28(typescript@5.9.3)":
+    dependencies:
+      "@volar/language-service": 2.4.28
+      "@volar/typescript": 2.4.28
+      typesafe-path: 0.2.2
+      typescript: 5.9.3
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+
+  "@volar/language-core@2.4.28":
+    dependencies:
+      "@volar/source-map": 2.4.28
+
+  "@volar/language-server@2.4.28":
+    dependencies:
+      "@volar/language-core": 2.4.28
+      "@volar/language-service": 2.4.28
+      "@volar/typescript": 2.4.28
+      path-browserify: 1.0.1
+      request-light: 0.7.0
+      vscode-languageserver: 9.0.1
+      vscode-languageserver-protocol: 3.17.5
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+
+  "@volar/language-service@2.4.28":
+    dependencies:
+      "@volar/language-core": 2.4.28
+      vscode-languageserver-protocol: 3.17.5
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+
+  "@volar/source-map@2.4.28": {}
+
+  "@volar/typescript@2.4.28":
+    dependencies:
+      "@volar/language-core": 2.4.28
+      path-browserify: 1.0.1
+      vscode-uri: 3.1.0
+
+  "@vscode/emmet-helper@2.11.0":
+    dependencies:
+      emmet: 2.4.11
+      jsonc-parser: 2.3.1
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.17.5
+      vscode-uri: 3.1.0
+
+  "@vscode/l10n@0.0.18": {}
+
   "@vue/compiler-core@3.5.28":
     dependencies:
       "@babel/parser": 7.29.0
@@ -12107,6 +12585,10 @@ snapshots:
   acorn@8.16.0: {}
 
   agent-base@7.1.4: {}
+
+  ajv-draft-04@1.0.0(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
 
   ajv-errors@3.0.0(ajv@8.18.0):
     dependencies:
@@ -12928,6 +13410,11 @@ snapshots:
       safe-buffer: 5.2.1
 
   ee-first@1.1.1: {}
+
+  emmet@2.4.11:
+    dependencies:
+      "@emmetio/abbreviation": 2.3.3
+      "@emmetio/css-abbreviation": 2.1.8
 
   emoji-regex@10.6.0: {}
 
@@ -14253,6 +14740,10 @@ snapshots:
 
   json-with-bigint@3.5.3: {}
 
+  jsonc-parser@2.3.1: {}
+
+  jsonc-parser@3.3.1: {}
+
   jsonpointer@5.0.1: {}
 
   jsonwebtoken@9.0.3:
@@ -14294,6 +14785,8 @@ snapshots:
   kind-of@6.0.3: {}
 
   kleur@3.0.3: {}
+
+  kleur@4.1.5: {}
 
   kuler@2.0.0: {}
 
@@ -14435,6 +14928,8 @@ snapshots:
   lodash.once@4.1.1: {}
 
   lodash.transform@4.6.0: {}
+
+  lodash@4.17.21: {}
 
   lodash@4.17.23: {}
 
@@ -15033,6 +15528,8 @@ snapshots:
 
   ms@2.1.3: {}
 
+  muggle-string@0.4.1: {}
+
   multiparty@4.2.3:
     dependencies:
       http-errors: 1.8.1
@@ -15507,6 +16004,8 @@ snapshots:
 
   parseurl@1.3.3: {}
 
+  path-browserify@1.0.1: {}
+
   path-exists@5.0.0: {}
 
   path-key@3.1.1: {}
@@ -15924,6 +16423,10 @@ snapshots:
       unified: 11.0.5
 
   remove-trailing-separator@1.1.0: {}
+
+  request-light@0.5.8: {}
+
+  request-light@0.7.0: {}
 
   require-directory@2.1.1: {}
 
@@ -16648,6 +17151,12 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
+  typesafe-path@0.2.2: {}
+
+  typescript-auto-import-cache@0.3.6:
+    dependencies:
+      semver: 7.7.4
+
   typescript@5.9.3: {}
 
   ufo@1.6.3: {}
@@ -16849,6 +17358,103 @@ snapshots:
     optionalDependencies:
       vite: 6.4.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
 
+  volar-service-css@0.0.68(@volar/language-service@2.4.28):
+    dependencies:
+      vscode-css-languageservice: 6.3.9
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      "@volar/language-service": 2.4.28
+
+  volar-service-emmet@0.0.68(@volar/language-service@2.4.28):
+    dependencies:
+      "@emmetio/css-parser": 0.4.1
+      "@emmetio/html-matcher": 1.3.0
+      "@vscode/emmet-helper": 2.11.0
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      "@volar/language-service": 2.4.28
+
+  volar-service-html@0.0.68(@volar/language-service@2.4.28):
+    dependencies:
+      vscode-html-languageservice: 5.6.1
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      "@volar/language-service": 2.4.28
+
+  volar-service-prettier@0.0.68(@volar/language-service@2.4.28)(prettier@3.8.1):
+    dependencies:
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      "@volar/language-service": 2.4.28
+      prettier: 3.8.1
+
+  volar-service-typescript-twoslash-queries@0.0.68(@volar/language-service@2.4.28):
+    dependencies:
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      "@volar/language-service": 2.4.28
+
+  volar-service-typescript@0.0.68(@volar/language-service@2.4.28):
+    dependencies:
+      path-browserify: 1.0.1
+      semver: 7.7.4
+      typescript-auto-import-cache: 0.3.6
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-nls: 5.2.0
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      "@volar/language-service": 2.4.28
+
+  volar-service-yaml@0.0.68(@volar/language-service@2.4.28):
+    dependencies:
+      vscode-uri: 3.1.0
+      yaml-language-server: 1.19.2
+    optionalDependencies:
+      "@volar/language-service": 2.4.28
+
+  vscode-css-languageservice@6.3.9:
+    dependencies:
+      "@vscode/l10n": 0.0.18
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.17.5
+      vscode-uri: 3.1.0
+
+  vscode-html-languageservice@5.6.1:
+    dependencies:
+      "@vscode/l10n": 0.0.18
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.17.5
+      vscode-uri: 3.1.0
+
+  vscode-json-languageservice@4.1.8:
+    dependencies:
+      jsonc-parser: 3.3.1
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.17.5
+      vscode-nls: 5.2.0
+      vscode-uri: 3.1.0
+
+  vscode-jsonrpc@8.2.0: {}
+
+  vscode-languageserver-protocol@3.17.5:
+    dependencies:
+      vscode-jsonrpc: 8.2.0
+      vscode-languageserver-types: 3.17.5
+
+  vscode-languageserver-textdocument@1.0.12: {}
+
+  vscode-languageserver-types@3.17.5: {}
+
+  vscode-languageserver@9.0.1:
+    dependencies:
+      vscode-languageserver-protocol: 3.17.5
+
+  vscode-nls@5.2.0: {}
+
+  vscode-uri@3.1.0: {}
+
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
@@ -16993,6 +17599,23 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@5.0.0: {}
+
+  yaml-language-server@1.19.2:
+    dependencies:
+      "@vscode/l10n": 0.0.18
+      ajv: 8.18.0
+      ajv-draft-04: 1.0.0(ajv@8.18.0)
+      lodash: 4.17.21
+      prettier: 3.8.1
+      request-light: 0.5.8
+      vscode-json-languageservice: 4.1.8
+      vscode-languageserver: 9.0.1
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.17.5
+      vscode-uri: 3.1.0
+      yaml: 2.7.1
+
+  yaml@2.7.1: {}
 
   yaml@2.8.2: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,5 @@
 {
-  "extends": "astro/tsconfigs/strict"
+  "extends": "astro/tsconfigs/strictest",
+  "include": [".astro/types.d.ts", "**/*"],
+  "exclude": ["dist"]
 }


### PR DESCRIPTION
## Summary
- switch TypeScript config to `astro/tsconfigs/strictest` and explicitly include `.astro/types.d.ts` and all project files while excluding `dist`
- add a dedicated `check` script (`astro check`) and required dependencies (`@astrojs/check`, `typescript`)
- enforce `check` in both CI (`quality-checks` workflow) and the local pre-commit hook, and update `AGENTS.md` to reflect the new required checks

## Verification
- `pnpm run check`
- `pnpm run build`